### PR TITLE
fix: canonicalize module path and remove self-referencing dependency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,7 +103,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - istio.io/
+        - github.com/theskyinflames/word2png/
   exclusions:
     generated: lax
     paths:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Gotchas & Sharp Edges
+
+- ~~**Module path is non-canonical:** `theskyinflames/word2png` (not `github.com/...`). go.mod also contains a self-referencing dependency `github.com/theskyinflames/word2png`. Don't blindly copy this pattern.~~ ✅ Fixed — module path is now `github.com/theskyinflames/word2png`, self-referencing dep removed.
+- **CI Go version is stale:** CI uses `go 1.21`; `go.mod` says `go 1.25.0`. Keep CI in sync if bumping.
+- **Formatters are enforced:** `gofumpt` + `goimports` run as linters. Run `golangci-lint run` locally (or `make lint`) before pushing — it also verifies `go mod tidy` didn't change anything (`git diff --quiet go.mod go.sum`).
+- **No real-crypto e2e test:** `lib/fixtures_test.go` uses generated mocks (`EncrypterMock`/`DecrypterMock`), so encryption/decryption round-trips are never tested with real AES-256. Don't assume integration coverage exists.
+- **`make generate` vendor dance:** It runs `go mod vendor` before `go generate ./...`, then removes `./vendor`. This may not work if vendor directory is gitignored or has stale contents.
+- **WASM build typo:** `make build-wasm` outputs `assets/world2png.wasm` (missing 'd'). Preserve filename for backward compatibility with `word2pngUI`.
+- **`os.Exit()` + non-standard code:** Both CLIs (`cmd/word2png/`, `cmd/png2word/`) call `os.Exit(-1)` on failure, skipping deferred cleanup. Handle with care.
+- **`cmd/wasm/` excluded from golangci-lint** (see `.golangci.yml` `build-tags: [infra]` and WASM build constraint).
+
+## Commands Quick Reference
+
+```bash
+make test          # go test -v -race ./...
+make lint          # golangci-lint run + go mod tidy -v && git diff --quiet go.mod go.sum
+make install       # builds + installs word2png and png2word binaries
+make build-wasm    # GOOS=js GOARCH=wasm → assets/world2png.wasm
+make generate      # go mod vendor + go generate ./... + rm -rf vendor
+make tools         # install golangci-lint v1.40.1, gofumpt, moq
+```

--- a/cmd/png2word/main.go
+++ b/cmd/png2word/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pterm/pterm"
+
 	"github.com/theskyinflames/word2png/lib"
 )
 

--- a/cmd/word2png/main.go
+++ b/cmd/word2png/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pterm/pterm"
+
 	"github.com/theskyinflames/word2png/lib"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module theskyinflames/word2png
+module github.com/theskyinflames/word2png
 
 go 1.25.0
 
@@ -6,7 +6,6 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.3.2
 	github.com/pterm/pterm v0.12.69
 	github.com/stretchr/testify v1.8.4
-	github.com/theskyinflames/word2png v0.0.0-20230310162449-716270965f75
 	golang.org/x/crypto v0.52.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/theskyinflames/word2png v0.0.0-20230310162449-716270965f75 h1:/v9JPvd6n/3NnGO3dR3km6kO7djJ10H5c6A+44emnyU=
-github.com/theskyinflames/word2png v0.0.0-20230310162449-716270965f75/go.mod h1:sEqjyLcA7jCDiW9eE/KfQKqeaC8+0NV1j5QX4Q+a6Ms=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=

--- a/lib/aes256_test.go
+++ b/lib/aes256_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/theskyinflames/word2png/lib"
 )
 

--- a/lib/color_test.go
+++ b/lib/color_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/theskyinflames/word2png/lib"
 )
 

--- a/lib/decode_test.go
+++ b/lib/decode_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/theskyinflames/word2png/lib"
 )
 

--- a/lib/encode_test.go
+++ b/lib/encode_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/theskyinflames/word2png/lib"
 )
 

--- a/lib/encoding-decoding_test.go
+++ b/lib/encoding-decoding_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/theskyinflames/word2png/lib"
 )
 


### PR DESCRIPTION
Changes:
- Module path: `theskyinflames/word2png` → `github.com/theskyinflames/word2png`
- Removed self-referencing dependency from `go.mod` and `go.sum`
- Fixed `goimports` local-prefixes in `.golangci.yml` (was orphaned `istio.io/`)
- Reformatted imports with `goimports -local` to use correct grouping
- Updated `AGENTS.md` to mark gotcha as resolved

Closes gotcha #1 from AGENTS.md.