### PR TITLE
fix: sync CI Go version with go.mod

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.25'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
-      - name: Set up Go 1.21
+      - name: Set up Go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25'
           cache: true
       - name: Unit tests
         run: make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Gotchas & Sharp Edges
+
+- **Module path is non-canonical:** `theskyinflames/word2png` (not `github.com/...`). go.mod also contains a self-referencing dependency `github.com/theskyinflames/word2png`. Don't blindly copy this pattern.
+- ~~**CI Go version is stale:** CI uses `go 1.21`; `go.mod` says `go 1.25.0`. Keep CI in sync if bumping.~~ ✅ Fixed — CI now uses `go 1.25` to match `go.mod`.
+- **Formatters are enforced:** `gofumpt` + `goimports` run as linters. Run `golangci-lint run` locally (or `make lint`) before pushing — it also verifies `go mod tidy` didn't change anything (`git diff --quiet go.mod go.sum`).
+- **No real-crypto e2e test:** `lib/fixtures_test.go` uses generated mocks (`EncrypterMock`/`DecrypterMock`), so encryption/decryption round-trips are never tested with real AES-256. Don't assume integration coverage exists.
+- **`make generate` vendor dance:** It runs `go mod vendor` before `go generate ./...`, then removes `./vendor`. This may not work if vendor directory is gitignored or has stale contents.
+- **WASM build typo:** `make build-wasm` outputs `assets/world2png.wasm` (missing 'd'). Preserve filename for backward compatibility with `word2pngUI`.
+- **`os.Exit()` + non-standard code:** Both CLIs (`cmd/word2png/`, `cmd/png2word/`) call `os.Exit(-1)` on failure, skipping deferred cleanup. Handle with care.
+- **`cmd/wasm/` excluded from golangci-lint** (see `.golangci.yml` `build-tags: [infra]` and WASM build constraint).
+
+## Commands Quick Reference
+
+```bash
+make test          # go test -v -race ./...
+make lint          # golangci-lint run + go mod tidy -v && git diff --quiet go.mod go.sum
+make install       # builds + installs word2png and png2word binaries
+make build-wasm    # GOOS=js GOARCH=wasm → assets/world2png.wasm
+make generate      # go mod vendor + go generate ./... + rm -rf vendor
+make tools         # install golangci-lint v1.40.1, gofumpt, moq
+```


### PR DESCRIPTION
Update CI Go version from 1.21 → 1.25 to match `go.mod`.

Changes:
- `.github/workflows/lint.yml`: go-version `1.21` → `1.25`
- `.github/workflows/test.yml`: go-version `1.21` → `1.25`
- Added `AGENTS.md` with known gotchas (PR #12 fix is not yet on main, so module path gotcha remains listed as unfixed)

Closes gotcha #2 from AGENTS.md.