### PR TITLE
fix: add real-crypto end-to-end test and regenerate stale mocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 ## Gotchas & Sharp Edges
 
 - ~~**`make generate` vendor dance:** It runs `go mod vendor` before `go generate ./...`, then removes `./vendor`. This may not work if vendor directory is gitignored or has stale contents.~~ ✅ Fixed — moq is now a `tool` dependency in `go.mod`, `//go:generate` uses `go run`, and `make generate` is just `go generate ./...`.
+- ~~**No real-crypto e2e test:** `lib/fixtures_test.go` uses generated mocks (`EncrypterMock`/`DecrypterMock`), so encryption/decryption round-trips are never tested with real AES-256. Don't assume integration coverage exists.~~ ✅ Fixed — `TestRealCryptoEncodingDecodingRoundTrip` in `lib/e2e_test.go` exercises full encode→decode pipeline with real AES-256.
 - **Formatters are enforced:** `gofumpt` + `goimports` run as linters. Run `golangci-lint run` locally (or `make lint`) before pushing — it also verifies `go mod tidy` didn't change anything (`git diff --quiet go.mod go.sum`).
-- **No real-crypto e2e test:** `lib/fixtures_test.go` uses generated mocks (`EncrypterMock`/`DecrypterMock`), so encryption/decryption round-trips are never tested with real AES-256. Don't assume integration coverage exists.
 - **WASM build typo:** `make build-wasm` outputs `assets/world2png.wasm` (missing 'd'). Preserve filename for backward compatibility with `word2pngUI`.
 - **`os.Exit()` + non-standard code:** Both CLIs (`cmd/word2png/`, `cmd/png2word/`) call `os.Exit(-1)` on failure, skipping deferred cleanup. Handle with care.
 - **`cmd/wasm/` excluded from golangci-lint** (see `.golangci.yml` `build-tags: [infra]` and WASM build constraint).

--- a/lib/e2e_test.go
+++ b/lib/e2e_test.go
@@ -1,0 +1,42 @@
+package lib_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theskyinflames/word2png/lib"
+)
+
+func TestRealCryptoEncodingDecodingRoundTrip(t *testing.T) {
+	const (
+		passphrase = "I'm glad to meet you in this dark times."
+		filePath   = "./result.png"
+	)
+
+	aes256 := lib.NewAES256(passphrase)
+
+	encoder := lib.NewEncoder(lib.Rune2Color(passphrase), aes256)
+	encodedImage, err := encoder.Encode(words)
+	require.NoError(t, err)
+	require.NotEmpty(t, encodedImage)
+
+	f, err := os.Create(filePath)
+	require.NoError(t, err)
+	_, err = f.Write(encodedImage)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	defer func() {
+		require.NoError(t, os.Remove(filePath))
+	}()
+
+	encodedImage, err = os.ReadFile(filePath)
+	require.NoError(t, err)
+	decoder := lib.NewDecoder(lib.Rune2Color(passphrase), aes256)
+	decodedWords, err := decoder.Decode(encodedImage)
+	require.NoError(t, err)
+
+	require.Equal(t, words, decodedWords)
+}

--- a/lib/zmock_decoder_test.go
+++ b/lib/zmock_decoder_test.go
@@ -4,8 +4,8 @@
 package lib_test
 
 import (
+	"github.com/theskyinflames/word2png/lib"
 	"sync"
-	"theskyinflames/word2png/lib"
 )
 
 // Ensure, that DecrypterMock does implement lib.Decrypter.

--- a/lib/zmock_encoder_test.go
+++ b/lib/zmock_encoder_test.go
@@ -4,8 +4,8 @@
 package lib_test
 
 import (
+	"github.com/theskyinflames/word2png/lib"
 	"sync"
-	"theskyinflames/word2png/lib"
 )
 
 // Ensure, that EncrypterMock does implement lib.Encrypter.


### PR DESCRIPTION
Changes:
- Added `TestRealCryptoEncodingDecodingRoundTrip` in `lib/e2e_test.go` that exercises the full encode→decode pipeline with real AES-256 (not mocks)
- Regenerated zmock files whose import paths were stale — PR #12 changed the module path but PR #14's mocks (merged after) were generated with the old path, breaking `main`
- Updated `AGENTS.md` to mark gotcha as resolved

Closes gotcha #3 from AGENTS.md.