### PR TITLE
fix: correct WASM build filename typo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - ~~**`make generate` vendor dance:** It runs `go mod vendor` before `go generate ./...`, then removes `./vendor`. This may not work if vendor directory is gitignored or has stale contents.~~ ✅ Fixed — moq is now a `tool` dependency in `go.mod`, `//go:generate` uses `go run`, and `make generate` is just `go generate ./...`.
 - ~~**No real-crypto e2e test:** `lib/fixtures_test.go` uses generated mocks (`EncrypterMock`/`DecrypterMock`), so encryption/decryption round-trips are never tested with real AES-256. Don't assume integration coverage exists.~~ ✅ Fixed — `TestRealCryptoEncodingDecodingRoundTrip` in `lib/e2e_test.go` exercises full encode→decode pipeline with real AES-256.
 - **Formatters are enforced:** `gofumpt` + `goimports` run as linters. Run `golangci-lint run` locally (or `make lint`) before pushing — it also verifies `go mod tidy` didn't change anything (`git diff --quiet go.mod go.sum`).
-- **WASM build typo:** `make build-wasm` outputs `assets/world2png.wasm` (missing 'd'). Preserve filename for backward compatibility with `word2pngUI`.
+- ~~**WASM build typo:** `make build-wasm` outputs `assets/world2png.wasm` (missing 'd'). Preserve filename for backward compatibility with `word2pngUI`.~~ ✅ Fixed — now outputs `word2png.wasm` with a copy as `world2png.wasm` for backward compat.
 - **`os.Exit()` + non-standard code:** Both CLIs (`cmd/word2png/`, `cmd/png2word/`) call `os.Exit(-1)` on failure, skipping deferred cleanup. Handle with care.
 - **`cmd/wasm/` excluded from golangci-lint** (see `.golangci.yml` `build-tags: [infra]` and WASM build constraint).
 
@@ -15,7 +15,7 @@
 make test          # go test -v -race ./...
 make lint          # golangci-lint run + go mod tidy -v && git diff --quiet go.mod go.sum
 make install       # builds + installs word2png and png2word binaries
-make build-wasm    # GOOS=js GOARCH=wasm → assets/world2png.wasm
+make build-wasm    # GOOS=js GOARCH=wasm → assets/word2png.wasm (+ world2png.wasm copy)
 make generate      # go generate ./...  (moq is a tool dep in go.mod)
 make tools         # install golangci-lint v1.40.1, gofumpt, moq
 ```

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ install:
 
 build-wasm:
 	mkdir -p ./assets
-	GOOS=js GOARCH=wasm go build -tags wasm -o ./assets/world2png.wasm ./cmd/wasm/main.go
+	GOOS=js GOARCH=wasm go build -tags wasm -o ./assets/word2png.wasm ./cmd/wasm/main.go
+	cp ./assets/word2png.wasm ./assets/world2png.wasm
 
 test:
 	go test -v -race ./...


### PR DESCRIPTION
Changes:
- Fixed typo in `make build-wasm`: outputs `word2png.wasm` instead of `world2png.wasm`
- Added `cp` step to preserve `world2png.wasm` for backward compatibility with `word2pngUI`
- Updated `AGENTS.md`

Closes gotcha #5 from AGENTS.md.