### PR TITLE
fix: refactor CLIs to main()->run() pattern and fix exit codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - ~~**No real-crypto e2e test:** `lib/fixtures_test.go` uses generated mocks (`EncrypterMock`/`DecrypterMock`), so encryption/decryption round-trips are never tested with real AES-256. Don't assume integration coverage exists.~~ ✅ Fixed — `TestRealCryptoEncodingDecodingRoundTrip` in `lib/e2e_test.go` exercises full encode→decode pipeline with real AES-256.
 - **Formatters are enforced:** `gofumpt` + `goimports` run as linters. Run `golangci-lint run` locally (or `make lint`) before pushing — it also verifies `go mod tidy` didn't change anything (`git diff --quiet go.mod go.sum`).
 - ~~**WASM build typo:** `make build-wasm` outputs `assets/world2png.wasm` (missing 'd'). Preserve filename for backward compatibility with `word2pngUI`.~~ ✅ Fixed — now outputs `word2png.wasm` with a copy as `world2png.wasm` for backward compat.
-- **`os.Exit()` + non-standard code:** Both CLIs (`cmd/word2png/`, `cmd/png2word/`) call `os.Exit(-1)` on failure, skipping deferred cleanup. Handle with care.
+- ~~**`os.Exit()` + non-standard code:** Both CLIs (`cmd/word2png/`, `cmd/png2word/`) call `os.Exit(-1)` on failure, skipping deferred cleanup. Handle with care.~~ ✅ Fixed — refactored to `main() -> run() int` pattern so defers fire before exit; replaced `os.Exit(-1)` with standard `os.Exit(1)`.
 - **`cmd/wasm/` excluded from golangci-lint** (see `.golangci.yml` `build-tags: [infra]` and WASM build constraint).
 
 ## Commands Quick Reference

--- a/cmd/png2word/main.go
+++ b/cmd/png2word/main.go
@@ -15,17 +15,16 @@ import (
 const defaultFilter = ".*"
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	var (
-		file   = kingpin.Flag("file", "Coded image to be used as words code if it's filled").Short('f').String()
-		b64    = kingpin.Flag("b64", "b64 string with the coded image").String()
-		debug  = kingpin.Flag("debug", "writes a debug file").Short('d').Bool()
-		filter = kingpin.Flag("filter", "only shows the words that match the regex expression").String()
-
-		// dangerous zone
+		file     = kingpin.Flag("file", "Coded image to be used as words code if it's filled").Short('f').String()
+		b64      = kingpin.Flag("b64", "b64 string with the coded image").String()
+		debug    = kingpin.Flag("debug", "writes a debug file").Short('d').Bool()
+		filter   = kingpin.Flag("filter", "only shows the words that match the regex expression").String()
 		showSeed = kingpin.Flag("show-seed", "shows the entered seed").Short('s').Bool()
-
-		debugFile *os.File
-		err       error
 	)
 	kingpin.Parse()
 
@@ -38,20 +37,28 @@ func main() {
 		*filter = defaultFilter
 	}
 	matchFilter, err := regexp.Compile(*filter)
-	exitIfError(err)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+		return 1
+	}
 
+	var debugFile *os.File
 	if debug != nil && *debug {
 		debugFile, err = os.Create("./decrypted-bytes.txt")
-		exitIfError(err)
-		defer func() {
-			debugFile.Close()
-		}()
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+			return 1
+		}
+		defer debugFile.Close()
 	}
 
 	decrypter := lib.NewAES256(seed)
 	decoder := lib.NewDecoder(lib.Rune2Color(seed), decrypter, lib.DecodeDebugWriterOpt(debugFile))
 	words, err := decoder.DecodeFromSource(*file, *b64)
-	exitIfError(err)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+		return 1
+	}
 
 	fmt.Println("decoding process finished.")
 	fmt.Printf("Have been decoded %d words:\n\n", len(words))
@@ -69,15 +76,8 @@ func main() {
 
 	err = pterm.DefaultTable.WithBoxed(true).WithHasHeader().WithRowSeparator("-").WithHeaderRowSeparator("-").WithLeftAlignment().WithData(values).Render()
 	if err != nil {
-		fmt.Printf("Something went wrong: %s", err.Error())
-		os.Exit(-1)
+		fmt.Printf("Something went wrong: %s\n", err.Error())
+		return 1
 	}
-	os.Exit(0)
-}
-
-func exitIfError(err error) {
-	if err != nil {
-		fmt.Printf("ERROR: %s\n", err.Error())
-		os.Exit(-1)
-	}
+	return 0
 }

--- a/cmd/word2png/main.go
+++ b/cmd/word2png/main.go
@@ -12,18 +12,17 @@ import (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	var (
 		imagePath   = kingpin.Flag("file", "Save to the especified file if it's filled").Short('f').String()
 		words       = kingpin.Flag("words", "list of words to encode").Short('w').Strings()
 		debug       = kingpin.Flag("debug", "writes a debug file").Short('d').Bool()
 		b64         = kingpin.Flag("b64", "b64encoded image").String()
 		removeWords = kingpin.Flag("remove-word", "remove a word from an image by index number").Short('r').Ints()
-
-		// dangerous zone
-		showSeed = kingpin.Flag("show-seed", "shows the entered seed").Short('s').Bool()
-
-		debugFile *os.File
-		err       error
+		showSeed    = kingpin.Flag("show-seed", "shows the entered seed").Short('s').Bool()
 	)
 	kingpin.Parse()
 
@@ -32,54 +31,61 @@ func main() {
 		pterm.DefaultBasicText.Printf("Entered seed: %s\n", pterm.BgYellow.Sprint(pterm.Black(seed)))
 	}
 
+	var debugFile *os.File
 	if debug != nil && *debug {
+		var err error
 		debugFile, err = os.Create("./encrypted-bytes.txt")
-		exitIfError(err)
-		defer func() {
-			debugFile.Close()
-		}()
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+			return 1
+		}
+		defer debugFile.Close()
 	}
 
 	aes256 := lib.NewAES256(seed)
 
-	// If the image already exists, received words will be appended to the existent ones
 	if (*imagePath != "" && imageExists(*imagePath)) || *b64 != "" {
 		decoder := lib.NewDecoder(lib.Rune2Color(seed), aes256, lib.DecodeDebugWriterOpt(debugFile))
 		beforeWords, err := decoder.DecodeFromSource(*imagePath, *b64)
-		exitIfError(err)
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+			return 1
+		}
 		*words = append(beforeWords, *words...)
 	}
 
-	// If remove-words flag has been provided, it's applied
 	*words = RemoveWordsByIdx(*words, *removeWords)
 
 	encoder := lib.NewEncoder(lib.Rune2Color(seed), aes256, lib.EncoderDebugWriterOpt(debugFile))
 	b, err := encoder.Encode(*words)
-	exitIfError(err)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+		return 1
+	}
 
 	switch {
 	case *imagePath != "":
-		exitIfError(lib.SaveEncodedImage(b, *imagePath))
+		if err := lib.SaveEncodedImage(b, *imagePath); err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+			return 1
+		}
 	default:
 		b64Encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
-		_, err = b64Encoder.Write(b)
-		exitIfError(err)
-		exitIfError(b64Encoder.Close())
+		if _, err = b64Encoder.Write(b); err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+			return 1
+		}
+		if err := b64Encoder.Close(); err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+			return 1
+		}
 	}
 
 	fmt.Println("\ncoding process finished")
-	os.Exit(0)
-}
-
-func exitIfError(err error) {
-	if err != nil {
-		fmt.Printf("ERROR: %s\n", err.Error())
-		os.Exit(-1)
-	}
+	return 0
 }
 
 func imageExists(imagePath string) bool {
-	// if error is nil, I guess the file exists
 	if _, err := os.Stat(imagePath); err == nil {
 		return true
 	}


### PR DESCRIPTION
Changes:
- Refactored both `cmd/word2png` and `cmd/png2word` to use `func main() { os.Exit(run()) }` pattern
- Deferred cleanup (e.g., `debugFile.Close()`) now properly fires before process exit
- Replaced all `os.Exit(-1)` with standard `os.Exit(1)`
- Removed `exitIfError` helper in both CLIs; errors handled inline
- Updated `AGENTS.md`

Closes gotcha #6 from AGENTS.md.